### PR TITLE
Add colour editing support

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import './App.css';
 
 // Code 39 Barcode Generator (replacing Code 128)
@@ -1626,7 +1626,8 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
 
   const startEdit = (item) => {
     setEditingItem(item.id);
-    setEditFormData(item);
+    // Ensure colour is included when starting an edit
+    setEditFormData({ ...item, colour: item.colour });
     setOriginalWarehouse(item.warehouse);
   };
 
@@ -1641,7 +1642,19 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
       return;
     }
     
-    updateWarehouseItem(editingItem, editFormData, originalData);
+    // Include colour so it can also be updated
+    updateWarehouseItem(
+      editingItem,
+      {
+        type: editFormData.type,
+        stage: editFormData.stage,
+        dateCreated: editFormData.dateCreated,
+        numberOfBundles: editFormData.numberOfBundles,
+        warehouse: editFormData.warehouse,
+        colour: editFormData.colour,
+      },
+      originalData
+    );
     setEditingItem(null);
     setEditFormData({});
   };
@@ -1822,8 +1835,8 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
                 </thead>
 <tbody className="divide-y divide-gray-200">
   {Object.entries(colours).map(([colour, rows]) => (
-    <React.Fragment key={`${product}-${colour}`}>
-      {/* “Colour” grouping row */}
+    <Fragment key={`${product}-${colour}`}>
+      {/* Colour grouping row */}
       <tr
         onClick={() => toggleColour(product, colour)}
         className="cursor-pointer hover:bg-gray-200"
@@ -1837,7 +1850,8 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
       {/* Expandable detail rows for just this product + this colour */}
       {expanded[`${product}-${colour}`] &&
         rows.map(item => (
-          <tr key={item.id} className="hover:bg-gray-50">
+          <Fragment key={item.id}>
+          <tr className="hover:bg-gray-50">
             <td className="px-6 py-4">
               <span className="font-mono text-sm text-blue-600">
                 {item.productId}
@@ -1967,11 +1981,7 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
               ) : (
                 <div className="flex gap-2">
                   <button
-                    onClick={() => {
-                      setEditingItem(item.id);
-                      setEditFormData(item);
-                      setOriginalWarehouse(item.warehouse);
-                    }}
+                    onClick={() => startEdit(item)}
                     className="text-blue-600 hover:text-blue-800 text-sm"
                   >
                     Edit
@@ -2001,8 +2011,28 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
               )}
             </td>
           </tr>
+          {editingItem === item.id && (
+            <tr className="bg-gray-50">
+              <td colSpan="7" className="px-6 py-3">
+                <select
+                  value={editFormData.colour}
+                  onChange={e =>
+                    setEditFormData({ ...editFormData, colour: e.target.value })
+                  }
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                >
+                  {settings.colors.map(color => (
+                    <option key={color} value={color}>
+                      {color}
+                    </option>
+                  ))}
+                </select>
+              </td>
+            </tr>
+          )}
+          </Fragment>
         ))}
-    </React.Fragment>
+    </Fragment>
   ))}
 </tbody>
               </table>


### PR DESCRIPTION
## Summary
- allow editing of colour in WarehouseView
- send updated colour to updateWarehouseItem
- populate edit form with item's colour
- use `<Fragment>` wrapper for JSX rows and import it from React

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_683f3196b864832bbbb112323d2d7404