### PR TITLE
Improve warehouse colour summaries

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1826,18 +1826,34 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
 <tbody className="divide-y divide-gray-200">
   {Object.entries(colours)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([colour, rows]) => (
-    <React.Fragment key={`${product}-${colour}`}>
-      {/* “Colour” grouping row */}
-      <tr
-        onClick={() => toggleColour(product, colour)}
-        className="cursor-pointer hover:bg-gray-200"
-      >
-        {/* colspan = number of <th> = 8 */}
-        <td colSpan="8" className="p-3 font-medium">
-          {colour}
-        </td>
-      </tr>
+    .map(([colour, rows]) => {
+      const totals = rows.reduce((acc, item) => {
+        acc[item.type] = (acc[item.type] || 0) + item.numberOfBundles;
+        return acc;
+      }, {});
+      const summary = TYPES.map(t =>
+        totals[t] ? `${t === 'Bundle' ? 'Bundles' : t}: ${totals[t]}` : null
+      )
+        .filter(Boolean)
+        .join(' ');
+      const isExpanded = expanded[`${product}-${colour}`];
+      return (
+        <React.Fragment key={`${product}-${colour}`}>
+          {/* "Colour" grouping row */}
+          <tr
+            onClick={() => toggleColour(product, colour)}
+            className="cursor-pointer hover:bg-gray-200"
+          >
+            {/* colspan = number of <th> = 8 */}
+            <td colSpan="8" className="p-3 font-medium">
+              <div className="flex justify-between items-center">
+                <span>
+                  {colour} {summary}
+                </span>
+                <span>{isExpanded ? '▼' : '▶'}</span>
+              </div>
+            </td>
+          </tr>
 
       {/* Expandable detail rows for just this product + this colour */}
       {expanded[`${product}-${colour}`] &&


### PR DESCRIPTION
## Summary
- enhance colour grouping rows in warehouse view to show totals
- display an expand/collapse icon in each colour row

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f5bafb0f8832bb2e2c1736da62b53