### PR TITLE
Fix material used calculation in UsingView

### DIFF
--- a/frontend/src/views/UsingView.js
+++ b/frontend/src/views/UsingView.js
@@ -180,7 +180,7 @@ const UsingView = ({ rawMaterials, useRawMaterial }) => {
                     <div>Weight Out: {formData.weightOut} lbs</div>
                     <div>Spillage: {formData.estimatedSpillage || 0} lbs</div>
                     <div className="font-medium pt-2 border-t">
-                      <strong>Material Used: {(parseFloat(formData.weightIn) - parseFloat(formData.weightOut) - parseFloat(formData.estimatedSpillage || 0)).toFixed(1)} lbs</strong>
+                      <strong>Material Used: {(parseFloat(formData.weightIn) - parseFloat(formData.weightOut)).toFixed(1)} lbs</strong>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- adjust usage calculation to exclude spillage

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840906426bc832b96658c25fc90c28b