### PR TITLE
Improve activity log structure

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -128,6 +128,17 @@ const initialActivityHistory = [
     action: 'Material Used',
     details: 'Barcode: BAR001PO5691, Used: 1159 lbs',
     user: 'Lead Hand - John Smith'
+  },
+  {
+    id: 3,
+    timestamp: '2024-12-16 09:00:00',
+    action: 'Raw Material Updated',
+    itemId: 'BAR001PO5691',
+    changes: {
+      bagsAvailable: { from: 6, to: 5 },
+      currentWeight: { from: 9259, to: 8100 }
+    },
+    user: 'Inventory Manager'
   }
 ];
 
@@ -179,11 +190,16 @@ function App() {
 
   // Enhanced activity logging for edits
   const addEditActivity = (action, itemId, changes, user = 'System') => {
-    const changeDetails = Object.entries(changes)
-      .map(([field, {from, to}]) => `${field}: "${from}" → "${to}"`)
-      .join(', ');
-    
-    addActivity(action, `${itemId} - ${changeDetails}`, user);
+    const newActivity = {
+      id: Math.max(...activityHistory.map(a => a.id), 0) + 1,
+      timestamp: new Date().toLocaleString(),
+      action,
+      itemId,
+      changes,
+      user
+    };
+
+    setActivityHistory([newActivity, ...activityHistory]);
   };
 
   // Generate barcode
@@ -236,7 +252,7 @@ function App() {
     if (Object.keys(changes).length > 0) {
       addEditActivity(
         'Raw Material Updated',
-        `Barcode: ${originalData.barcode}`,
+        originalData.barcode,
         changes,
         'Inventory Manager'
       );
@@ -425,7 +441,7 @@ function App() {
     if (Object.keys(changes).length > 0) {
       addEditActivity(
         'Warehouse Item Updated',
-        `Product ID: ${originalData.productId}`,
+        originalData.productId,
         changes,
         'Warehouse Manager'
       );

--- a/frontend/src/views/ActivityView.js
+++ b/frontend/src/views/ActivityView.js
@@ -11,7 +11,8 @@ const ActivityView = ({ activityHistory }) => {
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Details</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Item</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Changes / Details</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
               </tr>
             </thead>
@@ -24,7 +25,20 @@ const ActivityView = ({ activityHistory }) => {
                       {activity.action}
                     </span>
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-900">{activity.details}</td>
+                  <td className="px-6 py-4 text-sm text-gray-900">{activity.itemId || '-'}</td>
+                  <td className="px-6 py-4 text-sm text-gray-900">
+                    {activity.changes ? (
+                      <ul className="list-disc pl-4">
+                        {Object.entries(activity.changes).map(([field, value]) => (
+                          <li key={field}>
+                            {field}: "{value.from}" → "{value.to}"
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      activity.details
+                    )}
+                  </td>
                   <td className="px-6 py-4 text-sm text-gray-600">{activity.user}</td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- support structured edit activity history
- include example edited record
- render per-field changes in Activity History view

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684093b48b4c832b87c18b89b9012043