### PR TITLE
Sort dropdown lists alphabetically

### DIFF
--- a/frontend/src/views/ProductionView.js
+++ b/frontend/src/views/ProductionView.js
@@ -62,9 +62,12 @@ const ProductionView = ({ addProduction, settings }) => {
                 required
               >
                 <option value="">Select Colour</option>
-                {(settings?.colors || []).map(color => (
-                  <option key={color} value={color}>{color}</option>
-                ))}
+                {(settings?.colors || [])
+                  .slice()
+                  .sort((a, b) => a.localeCompare(b))
+                  .map(color => (
+                    <option key={color} value={color}>{color}</option>
+                  ))}
               </select>
             </div>
 

--- a/frontend/src/views/RawMaterialsView.js
+++ b/frontend/src/views/RawMaterialsView.js
@@ -127,9 +127,12 @@ const RawMaterialsView = ({ rawMaterials, updateRawMaterial, deleteRawMaterial, 
                                     onChange={(e) => setEditFormData({ ...editFormData, rawMaterial: e.target.value })}
                                     className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
                                   >
-                                    {settings.rawMaterials.map(rm => (
-                                      <option key={rm} value={rm}>{rm}</option>
-                                    ))}
+                                    {settings.rawMaterials
+                                      .slice()
+                                      .sort((a, b) => a.localeCompare(b))
+                                      .map(rm => (
+                                        <option key={rm} value={rm}>{rm}</option>
+                                      ))}
                                   </select>
                                 ) : (
                                   <span className="font-medium text-gray-900">{material.rawMaterial}</span>
@@ -142,9 +145,12 @@ const RawMaterialsView = ({ rawMaterials, updateRawMaterial, deleteRawMaterial, 
                                     onChange={(e) => setEditFormData({ ...editFormData, vendor: e.target.value })}
                                     className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
                                   >
-                                    {settings.vendors.map(vendor => (
-                                      <option key={vendor} value={vendor}>{vendor}</option>
-                                    ))}
+                                    {settings.vendors
+                                      .slice()
+                                      .sort((a, b) => a.localeCompare(b))
+                                      .map(vendor => (
+                                        <option key={vendor} value={vendor}>{vendor}</option>
+                                      ))}
                                   </select>
                                 ) : (
                                   <span className="text-gray-900">{material.vendor}</span>

--- a/frontend/src/views/ReceivingView.js
+++ b/frontend/src/views/ReceivingView.js
@@ -91,9 +91,12 @@ const ReceivingView = ({ addRawMaterial, settings }) => {
                 required
               >
                 <option value="">Select Raw Material</option>
-                {settings.rawMaterials.map(material => (
-                  <option key={material} value={material}>{material}</option>
-                ))}
+                {settings.rawMaterials
+                  .slice()
+                  .sort((a, b) => a.localeCompare(b))
+                  .map(material => (
+                    <option key={material} value={material}>{material}</option>
+                  ))}
               </select>
             </div>
 
@@ -118,9 +121,12 @@ const ReceivingView = ({ addRawMaterial, settings }) => {
                 required
               >
                 <option value="">Select Vendor</option>
-                {settings.vendors.map(vendor => (
-                  <option key={vendor} value={vendor}>{vendor}</option>
-                ))}
+                {settings.vendors
+                  .slice()
+                  .sort((a, b) => a.localeCompare(b))
+                  .map(vendor => (
+                    <option key={vendor} value={vendor}>{vendor}</option>
+                  ))}
               </select>
             </div>
 

--- a/frontend/src/views/WarehouseView.js
+++ b/frontend/src/views/WarehouseView.js
@@ -273,11 +273,14 @@ const WarehouseView = ({ inventory, allInventory, selectedWarehouse, setSelected
                   }
                   className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
                 >
-                  {settings.colors.map(c => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
+                    {settings.colors
+                      .slice()
+                      .sort((a, b) => a.localeCompare(b))
+                      .map(c => (
+                        <option key={c} value={c}>
+                          {c}
+                        </option>
+                      ))}
                 </select>
               ) : (
                 <span className="text-gray-900">{item.colour}</span>


### PR DESCRIPTION
## Summary
- ensure raw material, color and vendor dropdowns are sorted

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840a0054ebc832b889799af32903d0c