### PR TITLE
Add vendor dropdown to raw material values modal

### DIFF
--- a/frontend/src/views/SettingsView.js
+++ b/frontend/src/views/SettingsView.js
@@ -394,12 +394,19 @@ const SettingsView = ({ settings, updateSettings }) => {
                         />
                       </td>
                       <td className="px-2 py-1 border">
-                        <input
-                          type="text"
+                        <select
                           value={materialValues[name].vendor}
                           onChange={e => handleValueChange(name, 'vendor', e.target.value)}
                           className="w-full border rounded px-1"
-                        />
+                        >
+                          <option value="">Select Vendor</option>
+                          {formData.vendors
+                            .slice()
+                            .sort((a, b) => a.localeCompare(b))
+                            .map(vendor => (
+                              <option key={vendor} value={vendor}>{vendor}</option>
+                            ))}
+                        </select>
                       </td>
                       <td className="px-2 py-1 border">
                         <input


### PR DESCRIPTION
## Summary
- allow selecting vendor via dropdown instead of free text when editing raw material values

## Testing
- `yarn test --watchAll=false` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6840add251fc832b96d6e8a51715f173