### PR TITLE
Auto-select vendor on receiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Professional inventory tracking system for finished goods with barcode scanning 
 - Multi-location inventory (Dresden, BC, Buffalo)
 - Thermal label printing (Zebra 4" x 6")
 - Complete audit trail and activity history
+- Automatically selects a vendor in Receiving based on Settings
 
 ## Installation
 1. Clone repository: `git clone [your-repo-url]`

--- a/frontend/src/views/ReceivingView.js
+++ b/frontend/src/views/ReceivingView.js
@@ -22,6 +22,16 @@ const ReceivingView = ({ addRawMaterial, settings }) => {
     }
   }, [settings.vendors, settings.rawMaterials, formData.vendor, formData.rawMaterial]);
 
+  // Auto-select vendor when raw material changes based on settings
+  useEffect(() => {
+    if (!formData.rawMaterial) return;
+    const vendorVal = settings.rawMaterialValues?.[formData.rawMaterial]?.vendor;
+    const validVendor = vendorVal && settings.vendors.includes(vendorVal) ? vendorVal : '';
+    if (validVendor !== formData.vendor) {
+      setFormData(prev => ({ ...prev, vendor: validVendor }));
+    }
+  }, [formData.rawMaterial, settings.rawMaterialValues, settings.vendors]);
+
   // Force component to re-render when settings change
   const [refreshKey, setRefreshKey] = useState(0);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- auto-fill vendor in ReceivingView based on Settings
- document vendor auto-fill feature

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6840affa8184832bb0b724109af513c1