### PR TITLE
Add Avg Batches/Day field to settings

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,7 +26,13 @@ const initialSettings = {
   lowStockAlertLevel: 0.2, // 20% of starting weight
   rawMaterials: rawMaterialNames,
   rawMaterialValues: rawMaterialNames.reduce((acc, name) => {
-    acc[name] = { vendor: '', minQuantity: 0, pricePerLb: 0, usagePerBatch: 0 };
+    acc[name] = {
+      vendor: '',
+      minQuantity: 0,
+      pricePerLb: 0,
+      usagePerBatch: 0,
+      avgBatchesPerDay: 0
+    };
     return acc;
   }, {}),
   vendors: ['EFS Plastics', 'SM Polymers', 'Kraton', 'CRM Canada', 'Polyten', 'AWF'],
@@ -157,7 +163,21 @@ function App() {
     const normalizedValues = { ...baseValues };
     (loaded.rawMaterials || rawMaterialNames).forEach(name => {
       if (!normalizedValues[name]) {
-        normalizedValues[name] = { vendor: '', minQuantity: 0, pricePerLb: 0, usagePerBatch: 0 };
+        normalizedValues[name] = {
+          vendor: '',
+          minQuantity: 0,
+          pricePerLb: 0,
+          usagePerBatch: 0,
+          avgBatchesPerDay: 0
+        };
+      } else {
+        normalizedValues[name] = {
+          vendor: normalizedValues[name].vendor || '',
+          minQuantity: normalizedValues[name].minQuantity || 0,
+          pricePerLb: normalizedValues[name].pricePerLb || 0,
+          usagePerBatch: normalizedValues[name].usagePerBatch || 0,
+          avgBatchesPerDay: normalizedValues[name].avgBatchesPerDay || 0
+        };
       }
     });
     return { ...loaded, rawMaterialValues: normalizedValues };

--- a/frontend/src/views/SettingsView.js
+++ b/frontend/src/views/SettingsView.js
@@ -20,7 +20,16 @@ const SettingsView = ({ settings, updateSettings }) => {
           vendor: '',
           minQuantity: 0,
           pricePerLb: 0,
-          usagePerBatch: 0
+          usagePerBatch: 0,
+          avgBatchesPerDay: 0
+        };
+      } else {
+        normalizedValues[name] = {
+          vendor: normalizedValues[name].vendor || '',
+          minQuantity: normalizedValues[name].minQuantity || 0,
+          pricePerLb: normalizedValues[name].pricePerLb || 0,
+          usagePerBatch: normalizedValues[name].usagePerBatch || 0,
+          avgBatchesPerDay: normalizedValues[name].avgBatchesPerDay || 0
         };
       }
     });
@@ -36,7 +45,13 @@ const SettingsView = ({ settings, updateSettings }) => {
     if (newRawMaterial.trim() && !formData.rawMaterials.includes(newRawMaterial.trim())) {
       const updatedValues = {
         ...materialValues,
-        [newRawMaterial.trim()]: { vendor: '', minQuantity: 0, pricePerLb: 0, usagePerBatch: 0 }
+        [newRawMaterial.trim()]: {
+          vendor: '',
+          minQuantity: 0,
+          pricePerLb: 0,
+          usagePerBatch: 0,
+          avgBatchesPerDay: 0
+        }
       };
       const updatedFormData = {
         ...formData,
@@ -378,6 +393,7 @@ const SettingsView = ({ settings, updateSettings }) => {
                   <th className="px-2 py-1 border">Minimum Quantity (lb)</th>
                   <th className="px-2 py-1 border">Price Per lb (CDN)</th>
                   <th className="px-2 py-1 border">Usage / Batch (lb)</th>
+                  <th className="px-2 py-1 border">Avg Batches / Day</th>
                 </tr>
               </thead>
               <tbody>
@@ -432,6 +448,15 @@ const SettingsView = ({ settings, updateSettings }) => {
                           step="0.01"
                           value={materialValues[name].usagePerBatch}
                           onChange={e => handleValueChange(name, 'usagePerBatch', parseFloat(e.target.value) || 0)}
+                          className="w-full border rounded px-1"
+                        />
+                      </td>
+                      <td className="px-2 py-1 border">
+                        <input
+                          type="number"
+                          step="0.01"
+                          value={materialValues[name].avgBatchesPerDay}
+                          onChange={e => handleValueChange(name, 'avgBatchesPerDay', parseFloat(e.target.value) || 0)}
                           className="w-full border rounded px-1"
                         />
                       </td>


### PR DESCRIPTION
## Summary
- extend raw material settings with `avgBatchesPerDay`
- allow editing Avg Batches / Day in the Raw Material Values modal

## Testing
- `yarn test --watchAll=false` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6840c0930ae8832b9f03f0099570baea