### PR TITLE
Allow closing settings modal on overlay click

### DIFF
--- a/frontend/src/views/SettingsView.js
+++ b/frontend/src/views/SettingsView.js
@@ -382,8 +382,18 @@ const SettingsView = ({ settings, updateSettings }) => {
       </div>
 
       {showValuesModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-h-[80vh] overflow-y-auto w-full max-w-3xl">
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setShowValuesModal(false);
+            }
+          }}
+        >
+          <div
+            className="bg-white rounded-lg p-6 max-h-[80vh] overflow-y-auto w-full max-w-3xl"
+            onClick={(e) => e.stopPropagation()}
+          >
             <h3 className="text-lg font-semibold mb-4">Raw Material Values</h3>
             <table className="min-w-full border text-sm">
               <thead>


### PR DESCRIPTION
## Summary
- make raw material values dialog close when clicking the backdrop

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840c30dae74832ba130df535254745b