### PR TITLE
Switch dashboard low stock to min qty

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,7 +23,6 @@ const rawMaterialNames = [
 ];
 
 const initialSettings = {
-  lowStockAlertLevel: 0.2, // 20% of starting weight
   rawMaterials: rawMaterialNames,
   rawMaterialValues: rawMaterialNames.reduce((acc, name) => {
     acc[name] = {

--- a/frontend/src/views/DashboardView.js
+++ b/frontend/src/views/DashboardView.js
@@ -1,9 +1,10 @@
 import React from "react";
 const DashboardView = ({ rawMaterials, warehouseInventory, activityHistory, settings, setCurrentView }) => {
   const totalRawMaterialWeight = rawMaterials.reduce((sum, item) => sum + item.currentWeight, 0);
-  const lowStockRawMaterials = rawMaterials.filter(item => 
-    item.currentWeight < (item.startingWeight * settings.lowStockAlertLevel)
-  );
+  const lowStockRawMaterials = rawMaterials.filter(item => {
+    const minQty = settings.rawMaterialValues?.[item.rawMaterial]?.minQuantity || 0;
+    return item.currentWeight < minQty;
+  });
   const totalFinishedGoods = warehouseInventory.reduce((sum, item) => sum + item.numberOfBundles, 0);
   const recentActivities = activityHistory.slice(0, 5);
 
@@ -80,7 +81,9 @@ const DashboardView = ({ rawMaterials, warehouseInventory, activityHistory, sett
                     </div>
                     <div className="text-right">
                       <p className="text-sm font-medium text-red-600">{material.currentWeight.toLocaleString()} lbs</p>
-                      <p className="text-xs text-gray-500">{((material.currentWeight / material.startingWeight) * 100).toFixed(1)}% remaining</p>
+                      <p className="text-xs text-gray-500">
+                        Min: {(settings.rawMaterialValues?.[material.rawMaterial]?.minQuantity || 0).toLocaleString()} lbs
+                      </p>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/views/RawMaterialsView.js
+++ b/frontend/src/views/RawMaterialsView.js
@@ -32,10 +32,10 @@ const RawMaterialsView = ({ rawMaterials, updateRawMaterial, deleteRawMaterial, 
   };
 
   const getStatusInfo = (material) => {
-    const percentage = (material.currentWeight / material.startingWeight);
-    if (percentage < settings.lowStockAlertLevel) {
+    const minQty = settings.rawMaterialValues?.[material.rawMaterial]?.minQuantity || 0;
+    if (material.currentWeight < minQty) {
       return { status: 'Low Stock', color: 'bg-red-100 text-red-800' };
-    } else if (percentage < 0.5) {
+    } else if (material.currentWeight < minQty * 1.5 && minQty > 0) {
       return { status: 'Medium', color: 'bg-yellow-100 text-yellow-800' };
     } else {
       return { status: 'Good', color: 'bg-green-100 text-green-800' };

--- a/frontend/src/views/SettingsView.js
+++ b/frontend/src/views/SettingsView.js
@@ -184,33 +184,6 @@ const SettingsView = ({ settings, updateSettings }) => {
       <h2 className="text-3xl font-bold text-gray-900 mb-8">Settings</h2>
       
       <div className="space-y-8">
-        {/* Low Stock Alert Level */}
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <h3 className="text-lg font-semibold mb-4">Low Stock Alert Level</h3>
-          <div className="max-w-md">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Alert when raw material drops below this percentage of starting weight
-            </label>
-            <div className="flex items-center gap-4">
-              <input
-                type="range"
-                min="0.1"
-                max="0.5"
-                step="0.05"
-                value={formData.lowStockAlertLevel}
-                onChange={(e) => {
-                  const updatedFormData = {...formData, lowStockAlertLevel: parseFloat(e.target.value)};
-                  setFormData(updatedFormData);
-                  updateSettings(updatedFormData);
-                }}
-                className="flex-1"
-              />
-              <span className="text-lg font-medium w-16">
-                {(formData.lowStockAlertLevel * 100).toFixed(0)}%
-              </span>
-            </div>
-          </div>
-        </div>
 
         {/* Email Addresses Management */}
         <div className="bg-white rounded-lg shadow-sm border p-6">


### PR DESCRIPTION
## Summary
- remove low stock slider from settings
- compute low stock alerts using minimum quantity per material
- display each low stock material's minimum quantity on the dashboard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840c45d1b2c832b89cde1ad61c99ad3