### PR TITLE
Add editable avg batches setting

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,6 +34,7 @@ const initialSettings = {
     };
     return acc;
   }, {}),
+  avgBatchesPerDay: 0,
   vendors: ['EFS Plastics', 'SM Polymers', 'Kraton', 'CRM Canada', 'Polyten', 'AWF'],
   emailAddresses: ['jeddore.mcdonald@enviroshake.com'],
   colors: ['Weathered Wood', 'Cedar Blend', 'Rustic Red', 'Storm Grey', 'Charcoal', 'Midnight Blue', 'Weathered Copper', 'Driftwood', 'Sage Green', 'Coastal Blue', 'Autumn Bronze']
@@ -157,6 +158,9 @@ function App() {
   const [currentView, setCurrentView] = useState('dashboard');
   const [settings, setSettings] = useState(() => {
     const loaded = loadFromLocalStorage('enviroshake_settings', initialSettings);
+    if (loaded.avgBatchesPerDay === undefined) {
+      loaded.avgBatchesPerDay = 0;
+    }
     // Ensure rawMaterialValues exists for all raw materials
     const baseValues = loaded.rawMaterialValues || {};
     const normalizedValues = { ...baseValues };

--- a/frontend/src/views/SettingsView.js
+++ b/frontend/src/views/SettingsView.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from "react";
 const SettingsView = ({ settings, updateSettings }) => {
-  const [formData, setFormData] = useState(settings);
+  const [formData, setFormData] = useState({
+    ...settings,
+    avgBatchesPerDay: settings.avgBatchesPerDay || 0
+  });
   const [materialValues, setMaterialValues] = useState(settings.rawMaterialValues || {});
   const [showValuesModal, setShowValuesModal] = useState(false);
   const [newRawMaterial, setNewRawMaterial] = useState('');
@@ -10,7 +13,10 @@ const SettingsView = ({ settings, updateSettings }) => {
 
   // Update formData when settings prop changes
   useEffect(() => {
-    setFormData(settings);
+    setFormData({
+      ...settings,
+      avgBatchesPerDay: settings.avgBatchesPerDay || 0
+    });
     // Ensure materialValues contains an entry for every raw material
     const baseValues = settings.rawMaterialValues || {};
     const normalizedValues = { ...baseValues };
@@ -261,6 +267,20 @@ const SettingsView = ({ settings, updateSettings }) => {
           </div>
         </div>
 
+        {/* Avg Batches / Day */}
+        <div className="bg-white rounded-lg shadow-sm border p-6">
+          <h3 className="text-lg font-semibold mb-4">Avg Batches / Day</h3>
+          <div className="mb-4">
+            <input
+              type="number"
+              step="0.01"
+              value={formData.avgBatchesPerDay}
+              onChange={e => setFormData({ ...formData, avgBatchesPerDay: parseFloat(e.target.value) || 0 })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
         {/* Raw Materials Management */}
         <div className="bg-white rounded-lg shadow-sm border p-6">
           <h3 className="text-lg font-semibold mb-4 flex items-center justify-between">
@@ -376,7 +396,6 @@ const SettingsView = ({ settings, updateSettings }) => {
                   <th className="px-2 py-1 border">Minimum Quantity (lb)</th>
                   <th className="px-2 py-1 border">Price Per lb (CDN)</th>
                   <th className="px-2 py-1 border">Usage / Batch (lb)</th>
-                  <th className="px-2 py-1 border">Avg Batches / Day</th>
                 </tr>
               </thead>
               <tbody>
@@ -431,15 +450,6 @@ const SettingsView = ({ settings, updateSettings }) => {
                           step="0.01"
                           value={materialValues[name].usagePerBatch}
                           onChange={e => handleValueChange(name, 'usagePerBatch', parseFloat(e.target.value) || 0)}
-                          className="w-full border rounded px-1"
-                        />
-                      </td>
-                      <td className="px-2 py-1 border">
-                        <input
-                          type="number"
-                          step="0.01"
-                          value={materialValues[name].avgBatchesPerDay}
-                          onChange={e => handleValueChange(name, 'avgBatchesPerDay', parseFloat(e.target.value) || 0)}
                           className="w-full border rounded px-1"
                         />
                       </td>


### PR DESCRIPTION
## Summary
- add global Avg Batches / Day setting field
- include avgBatchesPerDay in settings model
- remove Avg Batches / Day column from Raw Material Values modal

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6840c8b1eefc832ba830ee4acd02cdd1