### PR TITLE
Add Lead Hand field to production view

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -516,14 +516,15 @@ function App() {
       dateCreated: new Date().toISOString().split('T')[0],
       warehouse: 'Dresden', // All production starts in Dresden
       stage: 'Available', // Default stage
-      shift: productionData.shift
+      shift: productionData.shift,
+      leadHandName: productionData.leadHandName
     };
 
     setWarehouseInventory([...warehouseInventory, newProduction]);
     addActivity(
       'Production Added',
       `Product ID: ${productId}, ${productionData.product} - ${productionData.colour} (${productionData.type}), ${productionData.numberOfBundles} bundles, ${productionData.shift} Shift`,
-      'Lead Hand'
+      `Lead Hand - ${productionData.leadHandName}`
     );
   };
 

--- a/frontend/src/views/ProductionView.js
+++ b/frontend/src/views/ProductionView.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { PRODUCTS, TYPES } from "../constants";
 const ProductionView = ({ addProduction, settings, openAlert }) => {
   const [formData, setFormData] = useState({
+    leadHandName: '',
     product: '',
     colour: '',
     type: '',
@@ -14,11 +15,13 @@ const ProductionView = ({ addProduction, settings, openAlert }) => {
     addProduction({
       ...formData,
       numberOfBundles: parseInt(formData.numberOfBundles),
-      shift: formData.shift
+      shift: formData.shift,
+      leadHandName: formData.leadHandName
     });
     
     // Reset form
     setFormData({
+      leadHandName: '',
       product: '',
       colour: '',
       type: '',
@@ -98,6 +101,18 @@ const ProductionView = ({ addProduction, settings, openAlert }) => {
                 <option value="Second">Second</option>
                 <option value="Third">Third</option>
               </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Lead Hand</label>
+              <input
+                type="text"
+                value={formData.leadHandName}
+                onChange={(e) => setFormData({...formData, leadHandName: e.target.value})}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                placeholder="Enter lead hand name"
+                required
+              />
             </div>
 
             <div>


### PR DESCRIPTION
## Summary
- capture lead hand name when logging production
- include lead hand name in activity logs

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6841df371ef8832b828125783597018b