### PR TITLE
Update Activity export options

### DIFF
--- a/frontend/src/views/ActivityView.js
+++ b/frontend/src/views/ActivityView.js
@@ -107,15 +107,9 @@ const ActivityView = ({ activityHistory, setActivityHistory }) => {
         <div>
           <button
             onClick={() => triggerExport("csv")}
-            className="mr-2 px-3 py-1 bg-blue-600 text-white rounded"
+            className="mr-2 px-3 py-1 bg-[#09713c] text-white rounded hover:bg-[#09713c]"
           >
             Export CSV
-          </button>
-          <button
-            onClick={() => triggerExport("json")}
-            className="px-3 py-1 bg-green-600 text-white rounded"
-          >
-            Export JSON
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the JSON export button from ActivityHistory view
- style the CSV export button to match the "Save Settings" button

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68470029dc08832b8df79317a5e43253