### PR TITLE
Fix initial weight field label

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -389,7 +389,7 @@ function App() {
       'Initial Weight Recorded',
       checkoutData.barcode,
       {
-        'Weigh In (lbs)': { from: null, to: checkoutData.weightIn }
+        'Weight In (lbs)': { from: null, to: checkoutData.weightIn }
       },
       `Lead Hand - ${checkoutData.leadHandName}`
     );


### PR DESCRIPTION
## Summary
- fix label used in activity logs for initial weight on UsingView

## Testing
- `yarn test --watchAll=false` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68472e85af64832bb40a01587836913b