### PR TITLE
Add notes to activity comments, remove old action

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -153,7 +153,7 @@ const initialActivityHistory = [
   {
     id: 2,
     timestamp: '2024-12-15 15:45:12',
-    action: 'Material Used',
+    action: 'End Weight Recorded',
     details: 'Barcode: BAR001PO5691, Used: 1159 lbs',
     user: 'Lead Hand - John Smith'
   },
@@ -372,11 +372,7 @@ function App() {
       );
     }
 
-    addActivity(
-      'Material Used',
-      `Barcode: ${usageData.barcode}, Used: ${weightUsed.toFixed(1)} lbs, Spillage: ${usageData.estimatedSpillage || 0} lbs, Finished Bag: ${usageData.finishedBag || 'No'}${usageData.notes ? `, Notes: ${usageData.notes}` : ''}`,
-      `Lead Hand - ${usageData.leadHandName}`
-    );
+    // Logging handled in checkinRawMaterial with "End Weight Recorded" action
   };
 
   const checkoutRawMaterial = (checkoutData) => {
@@ -421,7 +417,8 @@ function App() {
       fieldChanged: 'Weight Out (lbs)',
       value: weightOutNum,
       oldValue: oldWeight,
-      newValue: newWeight
+      newValue: newWeight,
+      comment: notes
     });
     setActivityHistory(history => [entryLog, ...history]);
   };

--- a/frontend/src/views/DashboardView.js
+++ b/frontend/src/views/DashboardView.js
@@ -17,7 +17,7 @@ const DashboardView = ({ rawMaterials, warehouseInventory, activityHistory, sett
 
   const totalWeightConsumedThisMonth = activityHistory
     .filter(activity => {
-      if (activity.action !== 'Material Used') return false;
+      if (activity.action !== 'End Weight Recorded') return false;
       const date = new Date(activity.timestamp);
       return (
         date.getMonth() === currentMonth &&
@@ -25,9 +25,10 @@ const DashboardView = ({ rawMaterials, warehouseInventory, activityHistory, sett
       );
     })
     .reduce((sum, activity) => {
-      const match = activity.details.match(/Used:\s*([\d,.]+)/i);
-      const used = match ? parseFloat(match[1].replace(/,/g, '')) : 0;
-      return sum + used;
+      const oldVal = parseFloat(activity.oldValue ?? 0);
+      const newVal = parseFloat(activity.newValue ?? oldVal);
+      const used = oldVal - newVal;
+      return sum + (isNaN(used) ? 0 : used);
     }, 0);
   const totalByMaterial = rawMaterials.reduce((acc, item) => {
     acc[item.rawMaterial] = (acc[item.rawMaterial] || 0) + item.currentWeight;

--- a/frontend/src/views/ReportsView.js
+++ b/frontend/src/views/ReportsView.js
@@ -40,7 +40,7 @@ const ReportsView = ({ rawMaterials, warehouseInventory, activityHistory }) => {
         case 'Receiving':
           return isInDateRange && activity.action === 'Raw Material Received';
         case 'Using':
-          return isInDateRange && activity.action === 'Material Used';
+          return isInDateRange && activity.action === 'End Weight Recorded';
         case 'Lead Hand Log':
           return isInDateRange && activity.action === 'Production Added';
         default:


### PR DESCRIPTION
## Summary
- change sample log action to `End Weight Recorded`
- drop `Material Used` logs and add comment handling
- compute consumption from `End Weight Recorded`
- update report filtering for the new action

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68473bbdb034832bb69cbc7fb24445c8