### PR TITLE
Add Daily Production Summary sidebar page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import ReportsView from './views/ReportsView';
 import SettingsView from './views/SettingsView';
 import ActivityView from './views/ActivityView';
 import ThisMonthView from './views/ThisMonthView';
+import DailyProductionSummaryView from './views/DailyProductionSummaryView';
 import AlertModal from './components/AlertModal';
 import { loadLogs, saveLogs, logActivity } from './utils/activityLog';
 
@@ -755,6 +756,15 @@ function App() {
             >
               📆 This Month
             </button>
+
+            <button
+              onClick={() => setCurrentView('dailyProductionSummary')}
+              className={`block w-full text-left py-2 px-3 rounded text-sm hover:bg-green-700 transition-colors ${
+                currentView === 'dailyProductionSummary' ? 'bg-green-700 text-white' : 'text-gray-300'
+              }`}
+            >
+              📅 Daily Production Summary
+            </button>
           </div>
 
           <div className="mt-6 px-6">
@@ -863,6 +873,10 @@ function App() {
             warehouseInventory={warehouseInventory}
             activityHistory={activityHistory}
           />
+        )}
+
+        {currentView === 'dailyProductionSummary' && (
+          <DailyProductionSummaryView />
         )}
       </div>
       {showAlert && (

--- a/frontend/src/views/DailyProductionSummaryView.js
+++ b/frontend/src/views/DailyProductionSummaryView.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const DailyProductionSummaryView = () => {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold text-gray-900 mb-8">Daily Production Summary</h2>
+    </div>
+  );
+};
+
+export default DailyProductionSummaryView;


### PR DESCRIPTION
## Summary
- add a blank Daily Production Summary view
- include Daily Production Summary in sidebar navigation

## Testing
- `yarn test --watchAll=false` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68484c97c7fc832b883862b15cb3208d