### PR TITLE
Implement form submission logging page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import WarehouseView from './views/WarehouseView';
 import ReportsView from './views/ReportsView';
 import SettingsView from './views/SettingsView';
 import ActivityView from './views/ActivityView';
+import ActivitySnapshotView from './views/ActivitySnapshotView';
 import ThisMonthView from './views/ThisMonthView';
 import DailyProductionSummaryView from './views/DailyProductionSummaryView';
 import AlertModal from './components/AlertModal';
@@ -779,7 +780,15 @@ function App() {
                 currentView === 'activity' ? 'bg-green-700 text-white' : 'text-gray-300'
               }`}
             >
-              📋 Activity History
+              📋 Activity
+            </button>
+            <button
+              onClick={() => setCurrentView('activityHistory')}
+              className={`block w-full text-left py-2 px-3 rounded text-sm hover:bg-green-700 transition-colors ${
+                currentView === 'activityHistory' ? 'bg-green-700 text-white' : 'text-gray-300'
+              }`}
+            >
+              📜 Activity History
             </button>
 
             <button
@@ -855,6 +864,10 @@ function App() {
         )}
         
         {currentView === 'activity' && (
+          <ActivitySnapshotView activityHistory={activityHistory} />
+        )}
+
+        {currentView === 'activityHistory' && (
           <ActivityView activityHistory={activityHistory} setActivityHistory={setActivityHistory} />
         )}
 

--- a/frontend/src/utils/activityLog.js
+++ b/frontend/src/utils/activityLog.js
@@ -33,7 +33,8 @@ export function logActivity({
   oldValue = null,
   newValue = null,
   comment = '',
-  referenceId = null
+  referenceId = null,
+  formData = null
 }) {
   const logs = loadLogs();
   const entry = {
@@ -48,7 +49,8 @@ export function logActivity({
     newValue,
     comment,
     referenceId,
-    details: comment // for backward compatibility
+    details: comment, // for backward compatibility
+    formData
   };
   logs.unshift(entry);
   saveLogs(logs);
@@ -64,6 +66,10 @@ export function updateComment(logId, comment) {
     return logs[idx];
   }
   return null;
+}
+
+export function logFormSubmission({ action = '', user = 'System', itemId = null, formData = {}, comment = '', referenceId = null }) {
+  return logActivity({ action, user, itemId, comment, referenceId, formData });
 }
 
 export function getLogs({
@@ -121,13 +127,17 @@ export function exportLogs(logs, format = 'csv') {
     'oldValue',
     'newValue',
     'comment',
-    'referenceId'
+    'referenceId',
+    'formData'
   ];
   const rows = [headers.join(',')];
   data.forEach(log => {
     const row = headers
       .map(h => {
-        const val = log[h] !== undefined && log[h] !== null ? log[h] : '';
+        let val = log[h] !== undefined && log[h] !== null ? log[h] : '';
+        if (typeof val === 'object') {
+          val = JSON.stringify(val);
+        }
         return `"${String(val).replace(/"/g, '""')}"`;
       })
       .join(',');

--- a/frontend/src/views/ActivitySnapshotView.js
+++ b/frontend/src/views/ActivitySnapshotView.js
@@ -1,0 +1,64 @@
+import React, { useMemo } from "react";
+
+const formatTimestamp = ts => {
+  const d = new Date(ts);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hours = String(d.getHours()).padStart(2, "0");
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+};
+
+const ActivitySnapshotView = ({ activityHistory }) => {
+  const logs = useMemo(
+    () => activityHistory.filter(l => l.formData),
+    [activityHistory]
+  );
+
+  const fields = useMemo(() => {
+    const set = new Set();
+    logs.forEach(l => {
+      Object.keys(l.formData || {}).forEach(f => set.add(f));
+    });
+    return Array.from(set).sort();
+  }, [logs]);
+
+  return (
+    <div>
+      <h2 className="text-3xl font-bold text-gray-900 mb-8">Activity</h2>
+      <div className="bg-white rounded-lg shadow-sm border overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-2 py-3 text-left">Timestamp</th>
+              <th className="px-2 py-3 text-left">Action</th>
+              <th className="px-2 py-3 text-left">User</th>
+              <th className="px-2 py-3 text-left">Item ID</th>
+              {fields.map(f => (
+                <th key={f} className="px-2 py-3 text-left">{f}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {logs.map(log => (
+              <tr key={log.id} className="hover:bg-gray-50">
+                <td className="px-2 py-2 whitespace-nowrap">{formatTimestamp(log.timestamp)}</td>
+                <td className="px-2 py-2 whitespace-nowrap">{log.action}</td>
+                <td className="px-2 py-2 whitespace-nowrap">{log.user}</td>
+                <td className="px-2 py-2 whitespace-nowrap">{log.itemId || '-'}</td>
+                {fields.map(f => (
+                  <td key={f} className="px-2 py-2 whitespace-nowrap">
+                    {log.formData && log.formData[f] !== undefined ? String(log.formData[f]) : '-'}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ActivitySnapshotView;

--- a/frontend/src/views/ProductionView.js
+++ b/frontend/src/views/ProductionView.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { PRODUCTS, TYPES } from "../constants";
+import { logFormSubmission } from "../utils/activityLog";
 
 const emptyBundle = { product: "", colour: "", type: "", numberOfBundles: "" };
 const emptyBatch = { batchesMade: "", colour: "" };
@@ -50,6 +51,19 @@ const ProductionView = ({ addProduction, settings, openAlert }) => {
         shift: basic.shift,
         numberOfBundles: parseInt(numberOfBundles) || 0,
       });
+    });
+
+    logFormSubmission({
+      action: 'Lead Hand Log',
+      user: `Lead Hand - ${basic.leadHandName}`,
+      formData: {
+        ...basic,
+        ...production,
+        bundles: JSON.stringify(bundles),
+        batches: JSON.stringify(batches),
+        binLevels: JSON.stringify(binLevels),
+        disposal: JSON.stringify(disposal)
+      }
     });
 
     setBasic({ leadHandName: "", shift: "First" });

--- a/frontend/src/views/ReceivingView.js
+++ b/frontend/src/views/ReceivingView.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { generateCode39Barcode, renderBarcodeSVG } from "../utils/barcode";
+import { logFormSubmission } from "../utils/activityLog";
 const ReceivingView = ({ addRawMaterial, settings, openAlert }) => {
   const [formData, setFormData] = useState({
     rawMaterial: '',
@@ -63,10 +64,17 @@ const ReceivingView = ({ addRawMaterial, settings, openAlert }) => {
       bagsReceived: parseInt(formData.bagsReceived),
       startingWeight: parseFloat(formData.startingWeight)
     });
-    
+
     setLabelData(currentLabelData);
     setGeneratedBarcode(barcode);
     setShowLabel(true);
+
+    logFormSubmission({
+      action: 'Receiving Form',
+      user: 'Purchasing Manager',
+      itemId: barcode,
+      formData: { ...formData, barcode }
+    });
     
     // Reset form
     setFormData({

--- a/frontend/src/views/UsingView.js
+++ b/frontend/src/views/UsingView.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { logFormSubmission } from "../utils/activityLog";
 const UsingView = ({ rawMaterials, openCheckouts, checkoutRawMaterial, checkinRawMaterial, openAlert }) => {
   const [formData, setFormData] = useState({
     barcode: '',
@@ -78,6 +79,12 @@ const UsingView = ({ rawMaterials, openCheckouts, checkoutRawMaterial, checkinRa
         leadHandName: formData.leadHandName,
         weightIn: parseFloat(formData.weightIn)
       });
+      logFormSubmission({
+        action: 'Initial Weight',
+        user: `Lead Hand - ${formData.leadHandName}`,
+        itemId: formData.barcode,
+        formData: { barcode: formData.barcode, leadHandName: formData.leadHandName, weightIn: formData.weightIn }
+      });
       openAlert('Material checked out successfully!');
     } else {
       if (!selectedCheckoutId) {
@@ -91,6 +98,18 @@ const UsingView = ({ rawMaterials, openCheckouts, checkoutRawMaterial, checkinRa
         formData.finishedBag,
         formData.notes
       );
+      logFormSubmission({
+        action: 'End Weight',
+        user: `Lead Hand - ${formData.leadHandName}`,
+        itemId: formData.barcode,
+        formData: {
+          barcode: formData.barcode,
+          weightOut: formData.weightOut,
+          estimatedSpillage: formData.estimatedSpillage,
+          finishedBag: formData.finishedBag,
+          notes: formData.notes
+        }
+      });
       openAlert('Material checked in successfully!');
       setSelectedCheckoutId('');
     }


### PR DESCRIPTION
## Summary
- log form data snapshots via `logFormSubmission`
- export form data in CSV/JSON
- add Activity snapshot view under System
- log all fields from Receiving, Using and Production forms
- update sidebar for new Activity pages

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684980af30d0832bbfd3588d4a826d4b