### PR TITLE
Fix sorting toggle in ActivitySnapshotView

### DIFF
--- a/frontend/src/views/ActivitySnapshotView.js
+++ b/frontend/src/views/ActivitySnapshotView.js
@@ -25,14 +25,16 @@ const ActivitySnapshotView = ({ activityHistory }) => {
     sortField === field ? (sortDirection === "asc" ? " \u25B2" : " \u25BC") : "";
 
   const handleSort = field => {
-    setSortField(prev => {
-      if (prev === field) {
-        setSortDirection(d => (d === "asc" ? "desc" : "asc"));
-        return field;
-      }
+    if (sortField === field) {
+      // Toggle direction when clicking the same header again
+      setSortDirection(d => (d === "asc" ? "desc" : "asc"));
+    } else {
+      // New field selected, default to ascending
+      setSortField(field);
       setSortDirection("asc");
-      return field;
-    });
+    }
+    // Ensure the field value is stored
+    setSortField(field);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix sort toggle in ActivitySnapshotView to alternate direction on repeated clicks

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684a0f5ac8f8832ba668f91608e21b73