### PR TITLE
Fix tile layout for production summary

### DIFF
--- a/frontend/src/views/DailyProductionSummaryView.js
+++ b/frontend/src/views/DailyProductionSummaryView.js
@@ -64,7 +64,7 @@ const DailyProductionSummaryView = ({ activityHistory }) => {
   return (
     <div>
       <h2 className="text-3xl font-bold text-gray-900 mb-8">Daily Production Summary</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div className="bg-white p-6 rounded-lg shadow-sm border">
           <h3 className="text-sm font-medium text-gray-500">Batches Made</h3>
           <p className="text-3xl font-bold text-blue-600 mt-2">{totals.batches}</p>


### PR DESCRIPTION
## Summary
- keep each pair of production stats on the same row by using a 2‑column grid

## Testing
- `yarn test --watchAll=false` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684ae2759950832bbd63e289c58ec3d4