### PR TITLE
Align CRA websocket port with dev server

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -31,7 +31,7 @@ fi
 
 # Update frontend environment variables if frontend directory exists
 if [ -d "/app/frontend" ]; then
-    echo "WDS_SOCKET_PORT=443" > /app/frontend/.env
+    echo "WDS_SOCKET_PORT=3000" > /app/frontend/.env
     echo "REACT_APP_BACKEND_URL=${preview_endpoint}" >> /app/frontend/.env
 fi
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-WDS_SOCKET_PORT=443
+WDS_SOCKET_PORT=3000
 REACT_APP_BACKEND_URL=https://02b5412a-cc40-4feb-b7fc-d0d47f6188cd.preview.emergentagent.com


### PR DESCRIPTION
## Summary
- set `WDS_SOCKET_PORT=3000` in container entrypoint
- update frontend `.env` accordingly

## Testing
- `yarn test` *(fails: package doesn't seem to be present)*
- `yarn install` *(fails: bad response 403)*

------
https://chatgpt.com/codex/tasks/task_b_684ca22a1e5c832b9131603fcb6bb2c7